### PR TITLE
Add wrapped heatmap configs/notebook

### DIFF
--- a/custom_rules.smk
+++ b/custom_rules.smk
@@ -63,3 +63,32 @@ docs["dms-viz visualizations"] = {
         for viz_name in dms_viz_config
     },
 }
+
+# Make row-wrapped heatmaps -------------------------------------------------------------
+
+# read configuration for wrapped heatmaps
+with open("data/wrapped_heatmap_config.yaml") as f:
+    wrapped_heatmap_config = yaml.YAML(typ="safe", pure=True).load(f)
+
+
+rule wrapped_heatmap:
+    """Make row-wrapped heatmaps."""
+    input:
+        data_csv=lambda wc: wrapped_heatmap_config[wc.wrapped_hm]["data_csv"],
+    output:
+        chart_html="results/wrapped_heatmaps/{wrapped_hm}_wrapped_heatmap.html",
+    params:
+        params_dict=lambda wc: wrapped_heatmap_config[wc.wrapped_hm]
+    log:
+        notebook="results/notebooks/wrapped_heatmap_{wrapped_hm}.ipynb",
+    conda:
+        os.path.join(config["pipeline_path"], "environment.yml"),
+    notebook:
+        "notebooks/wrapped_heatmap.py.ipynb"
+
+docs["Row-wrapped heatmaps"] = {
+    "Heatmap HTMLs" : {
+        wrapped_hm: rules.wrapped_heatmap.output.chart_html.format(wrapped_hm=wrapped_hm)
+        for wrapped_hm in wrapped_heatmap_config
+    }
+}

--- a/data/wrapped_heatmap_config.yaml
+++ b/data/wrapped_heatmap_config.yaml
@@ -1,0 +1,13 @@
+rsvF_293T_TIM1:
+  data_csv: results/summaries/cell_entry.csv
+  title: "Effect of mutations to RSV F protein on entry in 293T-TIM1 cells"
+  effect_col: "cell entry"
+  data_query_str: ""
+  sites_per_row: 126
+  site_label_freq: 10
+  site_label_start: 5  # start labeling at this site
+  color_scheme: redblue
+  fixed_min: -4
+  fixed_max: 2
+  alphabet: "RKHDEQNSTYWFAILMVGPC"
+  # dark_gray_muts: null   # optional; add if you want the gray overlay feature

--- a/notebooks/wrapped_heatmap.py.ipynb
+++ b/notebooks/wrapped_heatmap.py.ipynb
@@ -1,0 +1,142 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a616ff59-8358-45c1-8c35-87fbae29d675",
+   "metadata": {},
+   "source": [
+    "# Make a wrapped heatmap with multiple rows\n",
+    "This notebook makes wrapped heatmaps with multiple rows, designed for use as paper figures."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42e0d6c9-4481-478f-bd7b-5f0974b1169e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import altair as alt\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "_ = alt.data_transformers.disable_max_rows()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5cbc54b1-e592-4a04-9954-7be9600fa88e",
+   "metadata": {},
+   "source": [
+    "## Get configuration parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49f7c160-65ac-4023-bb51-d21ffc56a94c",
+   "metadata": {},
+   "source": [
+    "We get the parameters passed by `snakemake`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48308e90-bd88-4e79-8024-b3a86a5c0224",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": "data_csv = snakemake.input.data_csv\nchart_html = snakemake.output.chart_html\n\nparams_dict = snakemake.params.params_dict\ntitle = params_dict[\"title\"]\neffect_col = params_dict[\"effect_col\"]\ndata_query_str = params_dict[\"data_query_str\"]\nsites_per_row = params_dict[\"sites_per_row\"]\nsite_label_freq = params_dict[\"site_label_freq\"]\ncolor_scheme = params_dict[\"color_scheme\"]\nfixed_min = params_dict[\"fixed_min\"]\nfixed_max = params_dict[\"fixed_max\"]\nalphabet = params_dict[\"alphabet\"]\nif \"dark_gray_muts\" in params_dict:\n    dark_gray_muts = params_dict[\"dark_gray_muts\"]\nelse:\n    dark_gray_muts = None\nif \"site_label_start\" in params_dict:\n    site_label_start = params_dict[\"site_label_start\"]\nelse:\n    site_label_start = None"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c24ea151-1b5b-4a2b-9302-dd9078698acd",
+   "metadata": {},
+   "source": [
+    "## Read the input data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83339343-dce2-48c9-9422-e19bcdc21a20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if isinstance(alphabet, str):\n",
+    "    alphabet = list(alphabet)\n",
+    "\n",
+    "data = pd.read_csv(data_csv, dtype={\"site\": str})\n",
+    "print(f\"Read {len(data)=} with {data.columns=}\")\n",
+    "\n",
+    "if data_query_str:\n",
+    "    data = data.query(data_query_str).reset_index(drop=True)\n",
+    "    print(f\"After querying with {data_query_str=}, {len(data)=}\")\n",
+    "    \n",
+    "req_cols = [\"site\", \"sequential_site\", \"wildtype\", \"mutant\", effect_col]\n",
+    "assert set(req_cols).issubset(data.columns), f\"{data.columns=} lacks {req_cols=}\"\n",
+    "\n",
+    "if dark_gray_muts and (dark_gray_muts[\"col\"] not in data.columns):\n",
+    "    raise ValueError(f\"{dark_gray_muts['col']=} not in {data.columns=}\")\n",
+    "elif dark_gray_muts and (dark_gray_muts[\"col\"] not in req_cols):\n",
+    "    req_cols.append(dark_gray_muts[\"col\"])\n",
+    "\n",
+    "data = data[data[\"mutant\"].isin(alphabet) & data[\"wildtype\"].isin(alphabet)].reset_index(drop=True)\n",
+    "print(f\"After getting just amino acids of {alphabet=}, {len(data)=}\")\n",
+    "\n",
+    "data = data[req_cols]\n",
+    "assert len(data) == len(data.groupby([\"site\", \"wildtype\", \"mutant\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "947f5fd5-6248-4a7f-8caa-cfa3ba52f960",
+   "metadata": {},
+   "source": [
+    "## Make heatmap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16b5c852-2c22-4175-a2c1-4aedeae822c1",
+   "metadata": {},
+   "outputs": [],
+   "source": "heatmap_base = (\n    alt.Chart(data)\n    .encode(alt.Y(\"mutant\", sort=alphabet, title=\"amino acid\"))\n    .properties(width=alt.Step(9), height=alt.Step(9))\n)\n\nheatmap_bg = heatmap_base.transform_impute(\n    impute=\"_stat_dummy\",\n    key=\"mutant\",\n    keyvals=alphabet,\n    groupby=[\"site\"],\n    value=None,\n).mark_rect(color=\"#E0E0E0\", opacity=0.8)\n\nheatmap_wildtype = (\n    heatmap_base\n    .transform_filter(alt.datum[\"wildtype\"] == alt.datum[\"mutant\"])\n    .mark_text(text=\"x\", color=\"black\")\n)\n\nheatmap_muts = (\n    heatmap_base\n    .encode(\n        alt.Color(\n            effect_col,\n            scale=alt.Scale(\n                scheme=color_scheme,\n                domainMid=0,\n                domainMin=fixed_min,\n                domainMax=fixed_max,\n                clamp=True,\n            ),\n        ),\n        tooltip=[\"site\", \"mutant\", \"wildtype\", alt.Tooltip(effect_col, format=\".2f\")],\n    )\n    .mark_rect(stroke=\"black\", opacity=1, strokeOpacity=1)\n)\n\nif dark_gray_muts:\n    heatmap_muts = heatmap_muts.transform_filter(\n        alt.datum[dark_gray_muts[\"col\"]] >= dark_gray_muts[\"cutoff\"]\n    )\n\n    heatmap_dark_gray = (\n        heatmap_base\n        .transform_filter(alt.datum[dark_gray_muts[\"col\"]] < dark_gray_muts[\"cutoff\"])\n        .transform_calculate(filtered=\"0\")\n        .mark_rect(stroke=\"black\", opacity=1, strokeOpacity=1, color=\"silver\")\n    )\n\nheatmap_rows = []\nsequential_sites = sorted(data[\"sequential_site\"].unique())\nfor i in range(0, len(sequential_sites), sites_per_row):\n    row_sites = sequential_sites[i: i + sites_per_row]\n    last_row = row_sites[-1] == sequential_sites[-1]\n    sequential_to_site = data.set_index(\"sequential_site\")[\"site\"].to_dict()\n    \n    # label only some of the sites, starting at site_label_start and every site_label_freq\n    if site_label_start is not None:\n        # Calculate which sequential sites to label\n        to_label_sequential = []\n        current_label = site_label_start\n        while current_label <= row_sites[-1]:\n            if current_label >= row_sites[0]:  # only if in current row\n                to_label_sequential.append(current_label)\n            current_label += site_label_freq\n        to_label_values = [\n            sequential_to_site[seq_site]\n            for seq_site in to_label_sequential\n            if seq_site in sequential_to_site\n        ]\n    else:\n        # Default behavior: label from first site in row\n        to_label_values = [\n            sequential_to_site[i]\n            for i in range(row_sites[0], row_sites[-1], site_label_freq)\n        ]\n    \n    if dark_gray_muts:\n        row_charts = heatmap_bg + heatmap_dark_gray + heatmap_muts + heatmap_wildtype\n    else:\n        row_charts = heatmap_bg + heatmap_muts + heatmap_wildtype\n    heatmap_rows.append(\n        row_charts\n        .encode(\n            alt.X(\n                \"site:N\",\n                title=\"site\" if last_row else None,\n                sort=alt.SortField(\"sequential_site\"),\n                scale=alt.Scale(nice=False, zero=False),\n                axis=alt.Axis(values=to_label_values, labelAngle=0)\n            ),\n        )\n        .transform_filter(\n            (alt.datum[\"sequential_site\"] >= min(row_sites))\n            & (alt.datum[\"sequential_site\"] <= max(row_sites))\n        )\n    )\n\nheatmap = (\n    alt.vconcat(*heatmap_rows, spacing=6)\n    .configure_axis(tickColor=\"black\", tickSize=4, titleFontSize=16)\n    .configure_legend(\n        orient=\"bottom\",\n        gradientStrokeWidth=1,\n        gradientStrokeColor=\"black\",\n        titleAnchor=\"middle\",\n        titleFontSize=16,\n        titleLimit=200,\n    )\n    .properties(title=title)\n    .configure_title(anchor=\"middle\", fontSize=18)\n)\n\nprint(f\"Saving {chart_html=}\")\nheatmap.save(chart_html)\n\nheatmap"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22e621b2-9c0d-4351-832e-3102f09ea5d7",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
**Summary**
Wrapped cell entry heatmap for paper figure. 

**Changes**
  New files:
  - data/wrapped_heatmap_config.yaml 
  - notebooks/wrapped_heatmap.py.ipynb 

 Modified files:
  - custom_rules.smk 

 **Features**
  - Configurable visualization parameters (color scheme, min/max values, sites per row)
  - Specifies site labeling with customizable start position and frequency
  - Integrated into pipeline
  - Output: results/wrapped_heatmaps/{name}_wrapped_heatmap.html